### PR TITLE
feat: deduplicate subscription list

### DIFF
--- a/main.py
+++ b/main.py
@@ -242,9 +242,20 @@ class YouTubeMigrator:
         source_service = self.get_youtube_service(self.source_credentials)
         dest_service = self.get_youtube_service(self.destination_credentials)
         
-        # Get subscriptions from source account
-        subscriptions = self.get_subscriptions(source_service)
-        
+        # Get subscriptions from both accounts
+        source_subscriptions = self.get_subscriptions(source_service)
+        dest_subscriptions = self.get_subscriptions(dest_service)
+
+        # Filter out already subscribed channels
+        subscriptions = [
+            source_sub
+            for source_sub in source_subscriptions
+            if not any(
+                target_sub["channelId"] == source_sub["channelId"]
+                for target_sub in dest_subscriptions
+            )
+        ]
+
         print(f"\nMigrating {len(subscriptions)} subscriptions...")
         for sub in subscriptions:
             success = self.subscribe_to_channel(dest_service, sub['channelId'])


### PR DESCRIPTION
Hello!

First of all, thanks for the script!

I have a lot of subscriptions, and the first time that I ran the script I also ran out of API quota. No problem, I'll run it again.
Fast forward to the next day, I see a bunch of errors saying that I'm already subscribed to the channels. I didn't mind that, but then the errors changed — ran out of quota again :(

So this PR makes sure to only try to subscribe to channels that do not have a subscription yet.
Mind you, I'm not a Python developer, so I don't know a more efficient way to do it.